### PR TITLE
Upgrade to alpine 3.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1 (2026-08-24)
+
+- OS Alpine version 3.24.1
+
 ## 2.9 (2024-08-08)
 
 - OS Alpine version 3.22.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22.1
+FROM alpine:3.24.1
 LABEL maintainer="EEA: IDM2 A-Team <eea-edw-a-team-alerts@googlegroups.com>"
 
 


### PR DESCRIPTION
I propose to update the base OS to alpine 3.24.1. In my tests the image was working as expected but I do not have a Rancher environment nor remote shares to test with. 

I am not sure if I should update the CHANGELOG.md or if I should specify a version and release date in there. Maybe version 3.24.1 and the current date is fine. If not, I can also revert that part of the PR.